### PR TITLE
Expose `commit_date` field

### DIFF
--- a/floq-reports.cabal
+++ b/floq-reports.cabal
@@ -31,6 +31,7 @@ library
                      , servant-server
                      , string-conversions
                      , text
+                     , time
                      , transformers
                      , vector
                      , wai


### PR DESCRIPTION
Created orphan instances (☹️) for `ToJSON` and `ToField` for postgresql-simle's `Date` type so they can be converted to CSV and JSON.